### PR TITLE
Added valueFactor to datarecords for better conversion from m3

### DIFF
--- a/lib/wmbus_decoder.js
+++ b/lib/wmbus_decoder.js
@@ -1589,7 +1589,8 @@ class WMBUS_DECODER {
                 storageNo: item.DIB.storageNo,
                 devUnit: item.DIB.devUnit,
                 functionFieldText: item.DIB.functionFieldText,
-                functionField: item.DIB.functionField
+                functionField: item.DIB.functionField,
+                valueFactor: item.VIB.valueFactor
             });
         });
 


### PR DESCRIPTION
I think this change has value in case you want to convert units.
For example if we have IoT device with watermeter, thanks to valueFactor we will know if VIF_VOLUME is in liters or in 
m3.
```
DIF/VIF  04 13  -  0x13: ‘Volume l’,     - valueFactor: 0.001
DIF/VIF  04 16  -  0x16: ‘Volume m³’,  - valueFactor: 1
```
